### PR TITLE
Update to make compatable with Amazon keys

### DIFF
--- a/src/gauth.py
+++ b/src/gauth.py
@@ -59,7 +59,7 @@ def get_section_token(config, section):
 
     if secret:
         secret = secret.replace(' ', '')
-        secret = secret.ljust(int(math.ceil(len(secret) / 16.0) * 16), '=')
+        secret = secret.ljust(int(math.ceil(len(secret) / 8.0) * 8), '=')
         key = base64.b32decode(secret, casefold=True)
     return str(get_totp_token(key)).zfill(6)
 
@@ -71,7 +71,7 @@ def get_time_remaining():
 def is_secret_valid(secret):
     try:
         secret = secret.replace(' ', '')
-        secret = secret.ljust(int(math.ceil(len(secret) / 16.0) * 16), '=')
+        secret = secret.ljust(int(math.ceil(len(secret) / 8.0) * 8), '=')
         key = base64.b32decode(secret, casefold=True)
         get_totp_token(key)
     except:


### PR DESCRIPTION
Amazon uses an odd-length key, which the unchanged code rejects as not valid. This change lets the key be used and is backward compatibile with settings for other keys. Change suggested by TomekB in Alfred Forums
https://www.alfredforum.com/topic/4062-gauth-google-authenticator-time-based-two-factor-authentication/?do=findComment&comment=76857